### PR TITLE
Camera rotation

### DIFF
--- a/Engine/Component/ComponentCamera.cpp
+++ b/Engine/Component/ComponentCamera.cpp
@@ -77,6 +77,16 @@ void ComponentCamera::Update()
 	}
 
 	camera_frustum.pos = owner->transform.GetTranslation();
+
+	float3 ownerRotation = owner->transform.GetRotation();
+	Quat rotation_quat = Quat::FromEulerXYZ(
+		math::DegToRad(ownerRotation.x),
+		math::DegToRad(ownerRotation.y),
+		math::DegToRad(ownerRotation.z)
+	);	
+	camera_frustum.up = rotation_quat * float3::unitY;
+	camera_frustum.front = rotation_quat * float3::unitZ;
+
 	GenerateMatrices();
 }
 

--- a/Engine/Component/ComponentCamera.h
+++ b/Engine/Component/ComponentCamera.h
@@ -53,8 +53,9 @@ public:
 	void Center(const AABB &bounding_box);
 	void Focus(const AABB &bounding_box);
 
-	void RotatePitch(const float angle);
-	void RotateYaw(const float angle);
+	void RotateCameraWithMouseMotion(const float2 &motion);
+	Quat RotatePitch(const float angle);
+	Quat RotateYaw(const float angle);
 
 	void SetPerpesctiveView();
 	void SetOrthographicView();

--- a/Engine/Component/ComponentCamera.h
+++ b/Engine/Component/ComponentCamera.h
@@ -47,11 +47,12 @@ public:
 	void MoveLeft();
 	void MoveRight();
 
-	void OrbitX(const float angle);
-	void OrbitY(const float angle);
-
 	void Center(const AABB &bounding_box);
 	void Focus(const AABB &bounding_box);
+
+	void OrbitCameraWithMouseMotion(const float2 &motion);
+	void OrbitX(const float angle);
+	void OrbitY(const float angle);
 
 	void RotateCameraWithMouseMotion(const float2 &motion);
 	Quat RotatePitch(const float angle);

--- a/Engine/Component/ComponentCamera.h
+++ b/Engine/Component/ComponentCamera.h
@@ -55,8 +55,8 @@ public:
 	void OrbitY(const float angle);
 
 	void RotateCameraWithMouseMotion(const float2 &motion);
-	Quat RotatePitch(const float angle);
-	Quat RotateYaw(const float angle);
+	void RotatePitch(const float angle);
+	void RotateYaw(const float angle);
 
 	void SetPerpesctiveView();
 	void SetOrthographicView();

--- a/Engine/Component/ComponentTransform.cpp
+++ b/Engine/Component/ComponentTransform.cpp
@@ -89,7 +89,7 @@ float3 ComponentTransform::GetFrontVector() const
 
 float3 ComponentTransform::GetRightVector() const
 {
-	return rotation * float3::unitX;
+	return Cross(GetFrontVector(), GetUpVector());
 }
 
 void ComponentTransform::GenerateModelMatrix()

--- a/Engine/Component/ComponentTransform.cpp
+++ b/Engine/Component/ComponentTransform.cpp
@@ -42,6 +42,12 @@ void ComponentTransform::SetTranslation(const float3 translation)
 	GenerateModelMatrix(); // TODO: Change this to Update()
 }
 
+void ComponentTransform::Translate(const float3 &translation)
+{
+	this->translation += translation;
+	GenerateModelMatrix(); // TODO: Change this to Update()
+}
+
 float3 ComponentTransform::GetRotation() const
 {
 	return rotation;
@@ -50,6 +56,12 @@ float3 ComponentTransform::GetRotation() const
 void ComponentTransform::SetRotation(const float3 rotation)
 {
 	this->rotation = rotation;
+	GenerateModelMatrix(); // TODO: Change this to Update()
+}
+
+void ComponentTransform::Rotate(const float3 &rotation)
+{
+	this->rotation += rotation;
 	GenerateModelMatrix(); // TODO: Change this to Update()
 }
 

--- a/Engine/Component/ComponentTransform.cpp
+++ b/Engine/Component/ComponentTransform.cpp
@@ -39,7 +39,18 @@ float3 ComponentTransform::GetTranslation() const
 void ComponentTransform::SetTranslation(const float3 translation)
 {
 	this->translation = translation;
-	GenerateModelMatrix();
+	GenerateModelMatrix(); // TODO: Change this to Update()
+}
+
+float3 ComponentTransform::GetRotation() const
+{
+	return rotation;
+}
+
+void ComponentTransform::SetRotation(const float3 rotation)
+{
+	this->rotation = rotation;
+	GenerateModelMatrix(); // TODO: Change this to Update()
 }
 
 void ComponentTransform::GenerateModelMatrix()

--- a/Engine/Component/ComponentTransform.cpp
+++ b/Engine/Component/ComponentTransform.cpp
@@ -77,6 +77,21 @@ void ComponentTransform::Rotate(const float3x3 &rotation)
 	GenerateModelMatrix(); // TODO: Change this to Update()
 }
 
+float3 ComponentTransform::GetUpVector() const
+{
+	return rotation * float3::unitY;
+}
+
+float3 ComponentTransform::GetFrontVector() const
+{
+	return rotation * float3::unitZ;
+}
+
+float3 ComponentTransform::GetRightVector() const
+{
+	return rotation * float3::unitX;
+}
+
 void ComponentTransform::GenerateModelMatrix()
 {
 	model_matrix = float4x4::FromTRS(translation, rotation, scale);

--- a/Engine/Component/ComponentTransform.h
+++ b/Engine/Component/ComponentTransform.h
@@ -22,6 +22,9 @@ public:
 	float3 GetTranslation() const;
 	void SetTranslation(const float3 translation);
 
+	float3 GetRotation() const;
+	void SetRotation(const float3 rotation);
+
 	void GenerateGlobalModelMatrix();
 	void ChangeLocalSpace(const float4x4 new_local_space);
 

--- a/Engine/Component/ComponentTransform.h
+++ b/Engine/Component/ComponentTransform.h
@@ -29,6 +29,10 @@ public:
 	void Rotate(const Quat &rotation);
 	void Rotate(const float3x3 &rotation);
 
+	float3 GetUpVector() const;
+	float3 GetFrontVector() const;
+	float3 GetRightVector() const;
+
 	void GenerateGlobalModelMatrix();
 	void ChangeLocalSpace(const float4x4 new_local_space);
 

--- a/Engine/Component/ComponentTransform.h
+++ b/Engine/Component/ComponentTransform.h
@@ -11,7 +11,7 @@ class ComponentTransform : public Component
 {
 public:
 	ComponentTransform(GameObject * owner);
-	ComponentTransform(GameObject * owner,const float3 translation, const float3 rotation, const float3 scale);
+	ComponentTransform(GameObject * owner,const float3 translation, const Quat rotation, const float3 scale);
 
 	~ComponentTransform() = default;
 
@@ -23,9 +23,11 @@ public:
 	void SetTranslation(const float3 translation);
 	void Translate(const float3 &translation);
 
-	float3 GetRotation() const;
-	void SetRotation(const float3 rotation);
-	void Rotate(const float3 &rotation);
+	Quat GetRotation() const;
+	void SetRotation(const Quat &rotation);
+	void SetRotation(const float3x3 &rotation);
+	void Rotate(const Quat &rotation);
+	void Rotate(const float3x3 &rotation);
 
 	void GenerateGlobalModelMatrix();
 	void ChangeLocalSpace(const float4x4 new_local_space);
@@ -39,7 +41,7 @@ private:
 
 private:
 	float3 translation = float3::zero;
-	float3 rotation = float3::zero;
+	Quat rotation = Quat::identity;
 	float3 scale = float3::one;
 
 	float4x4 model_matrix = float4x4::identity;

--- a/Engine/Component/ComponentTransform.h
+++ b/Engine/Component/ComponentTransform.h
@@ -21,9 +21,11 @@ public:
 	
 	float3 GetTranslation() const;
 	void SetTranslation(const float3 translation);
+	void Translate(const float3 &translation);
 
 	float3 GetRotation() const;
 	void SetRotation(const float3 rotation);
+	void Rotate(const float3 &rotation);
 
 	void GenerateGlobalModelMatrix();
 	void ChangeLocalSpace(const float4x4 new_local_space);

--- a/Engine/Module/ModuleInput.cpp
+++ b/Engine/Module/ModuleInput.cpp
@@ -62,15 +62,10 @@ update_status ModuleInput::PreUpdate()
 				float2 motion = float2(event.motion.xrel, event.motion.yrel);
 				App->cameras->scene_camera->RotateCameraWithMouseMotion(motion);
 			}
-			else if (event.motion.state & SDL_BUTTON_LMASK && App->scene->scene_window_is_hovered && App->cameras->IsOrbiting()) {
-				if (math::Abs(event.motion.xrel) > 1.5) {
-					App->cameras->scene_camera->OrbitX(event.motion.xrel);
-				}
-
-				if (math::Abs(event.motion.yrel) > 1.5) {
-					App->cameras->scene_camera->OrbitY(event.motion.yrel);
-				}
-
+			else if (event.motion.state & SDL_BUTTON_LMASK && App->scene->scene_window_is_hovered && App->cameras->IsOrbiting()) 
+			{
+				float2 motion = float2(event.motion.xrel, event.motion.yrel);
+				App->cameras->scene_camera->OrbitCameraWithMouseMotion(motion);
 			}
 			break;
 
@@ -114,6 +109,10 @@ update_status ModuleInput::PreUpdate()
 				{
 					App->cameras->scene_camera->Focus(App->scene->hierarchy.selected_game_object->aabb.bounding_box);
 				}
+			}
+			else if (event.key.keysym.sym == SDLK_l)
+			{
+				App->cameras->scene_camera->LookAt(float3::zero);
 			}
 			break;
 

--- a/Engine/Module/ModuleInput.cpp
+++ b/Engine/Module/ModuleInput.cpp
@@ -110,10 +110,6 @@ update_status ModuleInput::PreUpdate()
 					App->cameras->scene_camera->Focus(App->scene->hierarchy.selected_game_object->aabb.bounding_box);
 				}
 			}
-			else if (event.key.keysym.sym == SDLK_l)
-			{
-				App->cameras->scene_camera->LookAt(float3::zero);
-			}
 			break;
 
 		case SDL_KEYUP:

--- a/Engine/Module/ModuleInput.cpp
+++ b/Engine/Module/ModuleInput.cpp
@@ -57,15 +57,10 @@ update_status ModuleInput::PreUpdate()
 			break;
 
 		case SDL_MOUSEMOTION:
-			if (event.motion.state & SDL_BUTTON_RMASK && App->scene->scene_window_is_hovered) {
-				if (math::Abs(event.motion.xrel) > 1.5) {
-					App->cameras->scene_camera->RotateYaw(event.motion.xrel);
-				}
-
-				if (math::Abs(event.motion.yrel) > 1.5) {
-					App->cameras->scene_camera->RotatePitch(event.motion.yrel);
-				}
-
+			if (event.motion.state & SDL_BUTTON_RMASK && App->scene->scene_window_is_hovered) 
+			{
+				float2 motion = float2(event.motion.xrel, event.motion.yrel);
+				App->cameras->scene_camera->RotateCameraWithMouseMotion(motion);
 			}
 			else if (event.motion.state & SDL_BUTTON_LMASK && App->scene->scene_window_is_hovered && App->cameras->IsOrbiting()) {
 				if (math::Abs(event.motion.xrel) > 1.5) {

--- a/Engine/UI/ComponentsUI.cpp
+++ b/Engine/UI/ComponentsUI.cpp
@@ -4,6 +4,7 @@
 #include "Component/ComponentMesh.h"
 #include "Component/ComponentTransform.h"
 #include "Texture.h"
+#include "Utils.h"
 
 #include <imgui.h>
 #include <FontAwesome5/IconsFontAwesome5.h>
@@ -16,8 +17,11 @@ void ComponentsUI::ShowComponentTransformWindow(ComponentTransform *transform)
 		{
 			transform->GenerateModelMatrix();
 		}
-		if (ImGui::DragFloat3("Rotation", &transform->rotation[0], 0.1f, -180.f, 180.f))
+
+		float3 temp_rotation = Utils::GenerateDegFloat3FromQuat(transform->rotation);
+		if (ImGui::DragFloat3("Rotation", &temp_rotation[0], 0.1f, -180.f, 180.f))
 		{
+			transform->rotation = Utils::GenerateQuatFromDegFloat3(temp_rotation);
 			transform->GenerateModelMatrix();
 		}
 		if (ImGui::DragFloat3("Scale", &transform->scale[0], 0.01f))

--- a/Engine/Utils.cpp
+++ b/Engine/Utils.cpp
@@ -1,0 +1,31 @@
+#include "Utils.h"
+
+
+
+Utils::Utils()
+{
+}
+
+
+Utils::~Utils()
+{
+}
+
+Quat Utils::GenerateQuatFromDegFloat3(const float3 &rotation)
+{
+	return Quat::FromEulerXYZ(
+		math::DegToRad(rotation.x),
+		math::DegToRad(rotation.y),
+		math::DegToRad(rotation.z)
+	);
+}
+
+float3 Utils::GenerateDegFloat3FromQuat(const Quat &rotation)
+{
+	float3 deg_rotation = rotation.ToEulerXYZ();
+	deg_rotation.x = math::RadToDeg(deg_rotation.x);
+	deg_rotation.y = math::RadToDeg(deg_rotation.y);
+	deg_rotation.z = math::RadToDeg(deg_rotation.z);
+
+	return deg_rotation;
+}

--- a/Engine/Utils.h
+++ b/Engine/Utils.h
@@ -1,0 +1,17 @@
+#ifndef _UTILS_H_
+#define _UTILS_H_
+
+#include "MathGeoLib.h"
+
+class Utils
+{
+public:
+	Utils();
+	~Utils();
+
+	static Quat GenerateQuatFromDegFloat3(const float3 &rotation);
+	static float3 GenerateDegFloat3FromQuat(const Quat &rotation);
+};
+
+#endif //_UTILS_H_
+

--- a/LittleOrionEngine.vcxproj
+++ b/LittleOrionEngine.vcxproj
@@ -177,6 +177,7 @@
     <ClInclude Include="Engine\Timer.h" />
     <ClInclude Include="Engine\TimerUs.h" />
     <ClInclude Include="Engine\Module\ModuleScene.h" />
+    <ClInclude Include="Engine\Utils.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Engine\Skybox.cpp" />
@@ -246,6 +247,7 @@
     <ClCompile Include="Engine\Timer.cpp" />
     <ClCompile Include="Engine\TimerUs.cpp" />
     <ClCompile Include="Engine\Module\ModuleScene.cpp" />
+    <ClCompile Include="Engine\Utils.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Libraries\MathGeoLib\include\Geometry\KDTree.inl" />


### PR DESCRIPTION
What's new:
- Refactor of `ComponentTransform`. 
- `ComponentTransform` rotation is now stored in Quats in order to simplify things.
- `ComponentTransform` has new methods to manage translation and rotation,
- `ComponentTransform` has up/right/front vector.
- `ComponentCamera` movements methods update owners `ComponentTransform`. In each update, camera frustum is updated with owner `ComponentTransform`.
- New class `Utils`, used to store utility functions,